### PR TITLE
feat: 道場管理ダッシュボード（的場予約・会員管理）

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ const navItems = [
 	{ to: "/practices", label: "稽古日誌" },
 	{ to: "/video-analysis", label: "動画分析" },
 	{ to: "/exam-checklist", label: "審査チェック" },
+	{ to: "/dashboard", label: "道場管理" },
 ] as const;
 
 export function AppLayout() {

--- a/src/components/member/MemberList.tsx
+++ b/src/components/member/MemberList.tsx
@@ -1,0 +1,94 @@
+import { DAN_LABELS, DAN_RANKS, SHOGO_LABELS } from "@/types/domain";
+import type { User } from "@/types/domain";
+import { useState } from "react";
+
+interface MemberListProps {
+	readonly members: readonly User[];
+}
+
+export function MemberList({ members }: MemberListProps) {
+	const [sortBy, setSortBy] = useState<"name" | "dan" | "joinedAt">("dan");
+
+	const sorted = [...members].sort((a, b) => {
+		if (sortBy === "name") return a.name.localeCompare(b.name);
+		if (sortBy === "joinedAt") return a.joinedAt.localeCompare(b.joinedAt);
+		// Sort by dan rank
+		const aIdx = a.dan ? DAN_RANKS.indexOf(a.dan) : -1;
+		const bIdx = b.dan ? DAN_RANKS.indexOf(b.dan) : -1;
+		return bIdx - aIdx;
+	});
+
+	const getDanDisplay = (user: User): string => {
+		const parts: string[] = [];
+		if (user.dan) parts.push(DAN_LABELS[user.dan]);
+		if (user.shogo) parts.push(SHOGO_LABELS[user.shogo]);
+		return parts.length > 0 ? parts.join(" / ") : "未取得";
+	};
+
+	if (members.length === 0) {
+		return <p>会員がいません</p>;
+	}
+
+	return (
+		<div>
+			<div
+				style={{
+					marginBottom: "1rem",
+					display: "flex",
+					gap: "0.5rem",
+					alignItems: "center",
+				}}
+			>
+				<span style={{ fontWeight: "bold" }}>ソート:</span>
+				{(["dan", "name", "joinedAt"] as const).map((key) => (
+					<button
+						key={key}
+						type="button"
+						onClick={() => setSortBy(key)}
+						style={{
+							padding: "0.25rem 0.75rem",
+							backgroundColor: sortBy === key ? "#1a1a2e" : "#e0e0e0",
+							color: sortBy === key ? "#fff" : "#333",
+							border: "none",
+							borderRadius: "4px",
+							cursor: "pointer",
+							fontSize: "0.85rem",
+						}}
+					>
+						{key === "dan" ? "段位" : key === "name" ? "名前" : "入会日"}
+					</button>
+				))}
+			</div>
+
+			<table style={{ borderCollapse: "collapse", width: "100%" }}>
+				<thead>
+					<tr>
+						{["名前", "段位・称号", "入会日", "連絡先"].map((h) => (
+							<th
+								key={h}
+								style={{
+									border: "1px solid #e0e0e0",
+									padding: "0.5rem",
+									backgroundColor: "#f5f5f5",
+									textAlign: "left",
+								}}
+							>
+								{h}
+							</th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					{sorted.map((member) => (
+						<tr key={member.id}>
+							<td style={{ border: "1px solid #e0e0e0", padding: "0.5rem" }}>{member.name}</td>
+							<td style={{ border: "1px solid #e0e0e0", padding: "0.5rem" }}>{getDanDisplay(member)}</td>
+							<td style={{ border: "1px solid #e0e0e0", padding: "0.5rem" }}>{member.joinedAt}</td>
+							<td style={{ border: "1px solid #e0e0e0", padding: "0.5rem" }}>{member.email}</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}

--- a/src/components/reservation/ReservationCalendar.tsx
+++ b/src/components/reservation/ReservationCalendar.tsx
@@ -1,0 +1,148 @@
+import { MOCK_USERS } from "@/lib/mock-data";
+import { generateTimeSlots } from "@/lib/reservation-validation";
+import type { Dojo, Reservation } from "@/types/domain";
+
+interface ReservationCalendarProps {
+	readonly dojo: Dojo;
+	readonly reservations: readonly Reservation[];
+	readonly selectedDate: string;
+	readonly onDateChange: (date: string) => void;
+	readonly onDeleteReservation: (id: string) => void;
+}
+
+function getUserName(userId: string): string {
+	return MOCK_USERS.find((u) => u.id === userId)?.name ?? userId;
+}
+
+export function ReservationCalendar({
+	dojo,
+	reservations,
+	selectedDate,
+	onDateChange,
+	onDeleteReservation,
+}: ReservationCalendarProps) {
+	const timeSlots = generateTimeSlots(dojo.openTime, dojo.closeTime);
+	const lanes = Array.from({ length: dojo.targetLanes }, (_, i) => i + 1);
+
+	const getReservation = (lane: number, time: string) =>
+		reservations.find((r) => r.laneNumber === lane && r.startTime === time && r.date === selectedDate);
+
+	return (
+		<div>
+			<div
+				style={{
+					display: "flex",
+					alignItems: "center",
+					gap: "1rem",
+					marginBottom: "1rem",
+				}}
+			>
+				<label htmlFor="calendar-date" style={{ fontWeight: "bold" }}>
+					日付:
+				</label>
+				<input
+					id="calendar-date"
+					type="date"
+					value={selectedDate}
+					onChange={(e) => onDateChange(e.target.value)}
+					style={{
+						padding: "0.5rem",
+						border: "1px solid #ccc",
+						borderRadius: "4px",
+					}}
+				/>
+			</div>
+
+			<div style={{ overflowX: "auto" }}>
+				<table
+					style={{
+						borderCollapse: "collapse",
+						width: "100%",
+						minWidth: "600px",
+					}}
+				>
+					<thead>
+						<tr>
+							<th
+								style={{
+									border: "1px solid #e0e0e0",
+									padding: "0.5rem",
+									backgroundColor: "#f5f5f5",
+								}}
+							>
+								時間
+							</th>
+							{lanes.map((lane) => (
+								<th
+									key={lane}
+									style={{
+										border: "1px solid #e0e0e0",
+										padding: "0.5rem",
+										backgroundColor: "#f5f5f5",
+									}}
+								>
+									的場 {lane}
+								</th>
+							))}
+						</tr>
+					</thead>
+					<tbody>
+						{timeSlots.map((time) => (
+							<tr key={time}>
+								<td
+									style={{
+										border: "1px solid #e0e0e0",
+										padding: "0.5rem",
+										fontWeight: "bold",
+										textAlign: "center",
+									}}
+								>
+									{time}
+								</td>
+								{lanes.map((lane) => {
+									const reservation = getReservation(lane, time);
+									return (
+										<td
+											key={lane}
+											style={{
+												border: "1px solid #e0e0e0",
+												padding: "0.5rem",
+												backgroundColor: reservation ? "#e3f2fd" : "#fff",
+												textAlign: "center",
+												fontSize: "0.85rem",
+											}}
+										>
+											{reservation ? (
+												<div>
+													<div>{getUserName(reservation.userId)}</div>
+													<button
+														type="button"
+														onClick={() => onDeleteReservation(reservation.id)}
+														style={{
+															marginTop: "0.25rem",
+															padding: "0.15rem 0.5rem",
+															fontSize: "0.75rem",
+															backgroundColor: "#d32f2f",
+															color: "#fff",
+															border: "none",
+															borderRadius: "3px",
+															cursor: "pointer",
+														}}
+													>
+														取消
+													</button>
+												</div>
+											) : (
+												<span style={{ color: "#ccc" }}>-</span>
+											)}
+										</td>
+									);
+								})}
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	);
+}

--- a/src/components/reservation/ReservationForm.tsx
+++ b/src/components/reservation/ReservationForm.tsx
@@ -1,0 +1,124 @@
+import { type ReservationFormValues, generateTimeSlots, reservationFormSchema } from "@/lib/reservation-validation";
+import type { Dojo } from "@/types/domain";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+
+interface ReservationFormProps {
+	readonly dojo: Dojo;
+	readonly onSubmit: (values: ReservationFormValues) => void;
+	readonly isSubmitting?: boolean;
+}
+
+export function ReservationForm({ dojo, onSubmit, isSubmitting = false }: ReservationFormProps) {
+	const {
+		register,
+		handleSubmit,
+		formState: { errors: rawErrors },
+	} = useForm({
+		resolver: zodResolver(reservationFormSchema),
+		defaultValues: {
+			date: new Date().toISOString().split("T")[0] ?? "",
+			startTime: "",
+			laneNumber: 1,
+		},
+	});
+
+	const timeSlots = generateTimeSlots(dojo.openTime, dojo.closeTime);
+	const lanes = Array.from({ length: dojo.targetLanes }, (_, i) => i + 1);
+
+	const fieldStyle = {
+		padding: "0.5rem",
+		border: "1px solid #ccc",
+		borderRadius: "4px",
+		fontSize: "1rem",
+	} as const;
+
+	const errorStyle = { color: "#d32f2f", fontSize: "0.85rem" } as const;
+
+	return (
+		<form
+			onSubmit={handleSubmit((values) => onSubmit(values as ReservationFormValues))}
+			style={{
+				display: "flex",
+				flexWrap: "wrap",
+				gap: "1rem",
+				alignItems: "flex-end",
+			}}
+		>
+			<div>
+				<label
+					htmlFor="res-date"
+					style={{
+						display: "block",
+						marginBottom: "0.25rem",
+						fontWeight: "bold",
+					}}
+				>
+					日付
+				</label>
+				<input id="res-date" type="date" {...register("date")} style={fieldStyle} />
+				{rawErrors.date?.message && <p style={errorStyle}>{rawErrors.date.message}</p>}
+			</div>
+
+			<div>
+				<label
+					htmlFor="res-time"
+					style={{
+						display: "block",
+						marginBottom: "0.25rem",
+						fontWeight: "bold",
+					}}
+				>
+					開始時刻
+				</label>
+				<select id="res-time" {...register("startTime")} style={fieldStyle}>
+					<option value="">選択</option>
+					{timeSlots.map((t) => (
+						<option key={t} value={t}>
+							{t}
+						</option>
+					))}
+				</select>
+				{rawErrors.startTime?.message && <p style={errorStyle}>{rawErrors.startTime.message}</p>}
+			</div>
+
+			<div>
+				<label
+					htmlFor="res-lane"
+					style={{
+						display: "block",
+						marginBottom: "0.25rem",
+						fontWeight: "bold",
+					}}
+				>
+					的場番号
+				</label>
+				<select id="res-lane" {...register("laneNumber")} style={fieldStyle}>
+					{lanes.map((l) => (
+						<option key={l} value={l}>
+							{l}
+						</option>
+					))}
+				</select>
+				{rawErrors.laneNumber?.message && <p style={errorStyle}>{rawErrors.laneNumber.message}</p>}
+			</div>
+
+			<button
+				type="submit"
+				disabled={isSubmitting}
+				style={{
+					padding: "0.5rem 1.5rem",
+					backgroundColor: "#1a1a2e",
+					color: "#fff",
+					border: "none",
+					borderRadius: "4px",
+					cursor: isSubmitting ? "not-allowed" : "pointer",
+					opacity: isSubmitting ? 0.7 : 1,
+					height: "fit-content",
+				}}
+			>
+				{isSubmitting ? "予約中..." : "予約する"}
+			</button>
+		</form>
+	);
+}

--- a/src/lib/reservation-validation.test.ts
+++ b/src/lib/reservation-validation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { generateTimeSlots, getEndTime, reservationFormSchema } from "./reservation-validation";
+
+describe("reservation-validation", () => {
+	describe("reservationFormSchema", () => {
+		it("有効な入力を受け付ける", () => {
+			const result = reservationFormSchema.safeParse({
+				date: "2026-04-01",
+				startTime: "10:00",
+				laneNumber: 1,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("空の日付を拒否する", () => {
+			const result = reservationFormSchema.safeParse({
+				date: "",
+				startTime: "10:00",
+				laneNumber: 1,
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it("空の開始時刻を拒否する", () => {
+			const result = reservationFormSchema.safeParse({
+				date: "2026-04-01",
+				startTime: "",
+				laneNumber: 1,
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("generateTimeSlots", () => {
+		it("9:00-21:00で12枠を生成する", () => {
+			const slots = generateTimeSlots("09:00", "21:00");
+			expect(slots).toHaveLength(12);
+			expect(slots[0]).toBe("09:00");
+			expect(slots[11]).toBe("20:00");
+		});
+
+		it("10:00-20:00で10枠を生成する", () => {
+			const slots = generateTimeSlots("10:00", "20:00");
+			expect(slots).toHaveLength(10);
+		});
+	});
+
+	describe("getEndTime", () => {
+		it("1時間後の時刻を返す", () => {
+			expect(getEndTime("09:00")).toBe("10:00");
+			expect(getEndTime("14:00")).toBe("15:00");
+			expect(getEndTime("20:00")).toBe("21:00");
+		});
+	});
+});

--- a/src/lib/reservation-validation.ts
+++ b/src/lib/reservation-validation.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/** 予約フォームのバリデーションスキーマ */
+export const reservationFormSchema = z.object({
+	date: z.string().min(1, "日付を入力してください"),
+	startTime: z.string().min(1, "開始時刻を選択してください"),
+	laneNumber: z.coerce.number().int().min(1, "的場番号を選択してください"),
+});
+
+export type ReservationFormValues = z.infer<typeof reservationFormSchema>;
+
+/** 営業時間内の1時間単位の時間帯を生成 */
+export function generateTimeSlots(openTime: string, closeTime: string): readonly string[] {
+	const openHour = Number.parseInt(openTime.split(":")[0] ?? "9", 10);
+	const closeHour = Number.parseInt(closeTime.split(":")[0] ?? "21", 10);
+	const slots: string[] = [];
+	for (let h = openHour; h < closeHour; h++) {
+		slots.push(`${String(h).padStart(2, "0")}:00`);
+	}
+	return slots;
+}
+
+/** 終了時刻を計算（1時間単位） */
+export function getEndTime(startTime: string): string {
+	const hour = Number.parseInt(startTime.split(":")[0] ?? "0", 10);
+	return `${String(hour + 1).padStart(2, "0")}:00`;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardPage } from "@/pages/DashboardPage";
 import { ExamChecklistPage } from "@/pages/ExamChecklistPage";
 import { HomePage } from "@/pages/HomePage";
 import { PracticesPage } from "@/pages/PracticesPage";
@@ -16,8 +17,9 @@ if (rootElement) {
 					<Route element={<AppLayout />}>
 						<Route index element={<HomePage />} />
 						<Route path="practices" element={<PracticesPage />} />
-						<Route path="exam-checklist" element={<ExamChecklistPage />} />
 						<Route path="video-analysis" element={<VideoAnalysisPage />} />
+						<Route path="exam-checklist" element={<ExamChecklistPage />} />
+						<Route path="dashboard" element={<DashboardPage />} />
 					</Route>
 				</Routes>
 			</BrowserRouter>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,0 +1,167 @@
+import { MemberList } from "@/components/member/MemberList";
+import { ReservationCalendar } from "@/components/reservation/ReservationCalendar";
+import { ReservationForm } from "@/components/reservation/ReservationForm";
+import type { DashboardSummary } from "@/lib/mock-api";
+import {
+	createReservation,
+	deleteReservation,
+	getDashboardSummary,
+	getDojo,
+	getReservations,
+	getUsersByDojo,
+} from "@/lib/mock-api";
+import { getEndTime } from "@/lib/reservation-validation";
+import type { ReservationFormValues } from "@/lib/reservation-validation";
+import type { Dojo, Reservation, User } from "@/types/domain";
+import { useCallback, useEffect, useState } from "react";
+
+/** 現在のモック道場ID */
+const CURRENT_DOJO_ID = "dojo-001";
+const CURRENT_USER_ID = "user-002"; // 管理者ユーザー
+
+export function DashboardPage() {
+	const [dojo, setDojo] = useState<Dojo | null>(null);
+	const [reservations, setReservations] = useState<readonly Reservation[]>([]);
+	const [members, setMembers] = useState<readonly User[]>([]);
+	const [summary, setSummary] = useState<DashboardSummary | null>(null);
+	const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split("T")[0] ?? "");
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [activeTab, setActiveTab] = useState<"calendar" | "members">("calendar");
+
+	const loadData = useCallback(async () => {
+		const [dojoResult, resResult, membersResult, summaryResult] = await Promise.all([
+			getDojo(CURRENT_DOJO_ID),
+			getReservations(CURRENT_DOJO_ID),
+			getUsersByDojo(CURRENT_DOJO_ID),
+			getDashboardSummary(CURRENT_DOJO_ID),
+		]);
+
+		if (dojoResult.success) setDojo(dojoResult.data);
+		if (resResult.success) setReservations(resResult.data);
+		if (membersResult.success) setMembers(membersResult.data);
+		if (summaryResult.success) setSummary(summaryResult.data);
+	}, []);
+
+	useEffect(() => {
+		void loadData();
+	}, [loadData]);
+
+	const handleCreateReservation = async (values: ReservationFormValues) => {
+		setIsSubmitting(true);
+		await createReservation({
+			dojoId: CURRENT_DOJO_ID,
+			userId: CURRENT_USER_ID,
+			laneNumber: values.laneNumber,
+			date: values.date,
+			startTime: values.startTime,
+			endTime: getEndTime(values.startTime),
+		});
+		setIsSubmitting(false);
+		await loadData();
+	};
+
+	const handleDeleteReservation = async (id: string) => {
+		await deleteReservation(id);
+		await loadData();
+	};
+
+	if (!dojo) return <p>読み込み中...</p>;
+
+	const tabStyle = (tab: "calendar" | "members") =>
+		({
+			padding: "0.5rem 1.5rem",
+			backgroundColor: activeTab === tab ? "#1a1a2e" : "#e0e0e0",
+			color: activeTab === tab ? "#fff" : "#333",
+			border: "none",
+			borderRadius: "4px 4px 0 0",
+			cursor: "pointer",
+			fontSize: "1rem",
+		}) as const;
+
+	return (
+		<div>
+			<h1>道場管理ダッシュボード</h1>
+			<p style={{ color: "#666", marginBottom: "1.5rem" }}>{dojo.name}</p>
+
+			{summary && (
+				<div
+					style={{
+						display: "flex",
+						gap: "1.5rem",
+						marginBottom: "2rem",
+						flexWrap: "wrap",
+					}}
+				>
+					<div
+						style={{
+							padding: "1.5rem",
+							backgroundColor: "#e3f2fd",
+							borderRadius: "8px",
+							flex: "1 1 200px",
+							textAlign: "center",
+						}}
+					>
+						<div style={{ fontSize: "2rem", fontWeight: "bold" }}>{summary.todayReservationCount}</div>
+						<div style={{ color: "#555" }}>本日の予約</div>
+					</div>
+					<div
+						style={{
+							padding: "1.5rem",
+							backgroundColor: "#e8f5e9",
+							borderRadius: "8px",
+							flex: "1 1 200px",
+							textAlign: "center",
+						}}
+					>
+						<div style={{ fontSize: "2rem", fontWeight: "bold" }}>{summary.totalMemberCount}</div>
+						<div style={{ color: "#555" }}>会員数</div>
+					</div>
+				</div>
+			)}
+
+			<div style={{ display: "flex", gap: "0.25rem", marginBottom: "0" }}>
+				<button type="button" onClick={() => setActiveTab("calendar")} style={tabStyle("calendar")}>
+					予約カレンダー
+				</button>
+				<button type="button" onClick={() => setActiveTab("members")} style={tabStyle("members")}>
+					会員管理
+				</button>
+			</div>
+
+			<div
+				style={{
+					border: "1px solid #e0e0e0",
+					borderRadius: "0 8px 8px 8px",
+					padding: "1.5rem",
+				}}
+			>
+				{activeTab === "calendar" && (
+					<>
+						<section style={{ marginBottom: "1.5rem" }}>
+							<h2>新規予約</h2>
+							<ReservationForm dojo={dojo} onSubmit={handleCreateReservation} isSubmitting={isSubmitting} />
+						</section>
+
+						<section>
+							<h2>予約カレンダー</h2>
+							<ReservationCalendar
+								dojo={dojo}
+								reservations={reservations}
+								selectedDate={selectedDate}
+								onDateChange={setSelectedDate}
+								onDeleteReservation={handleDeleteReservation}
+							/>
+						</section>
+					</>
+				)}
+
+				{activeTab === "members" && (
+					<section>
+						<h2>会員一覧 ({members.length}名)</h2>
+						<MemberList members={members} />
+					</section>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -22,6 +22,9 @@ export function HomePage() {
 				<Link to="/exam-checklist" style={{ fontSize: "1.1rem" }}>
 					段位審査チェックリスト
 				</Link>
+				<Link to="/dashboard" style={{ fontSize: "1.1rem" }}>
+					道場管理ダッシュボード
+				</Link>
 			</nav>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- 的場予約カレンダー（時間帯 x 的場レーン グリッド、日付切替、予約作成・削除）
- 会員一覧（段位/名前/入会日ソート対応、段位・称号・連絡先表示）
- ダッシュボードトップ（本日の予約数・会員数サマリーカード）
- タブ切替UI（予約カレンダー / 会員管理）
- 予約バリデーション（Zod: 日付・時刻・的場番号）

## Test plan
- [x] `make check` 全パス
- [x] 60テスト全パス（予約バリデーション 6件含む）
- [x] 予約の作成・削除・カレンダー表示

Closes #10