### PR TITLE
fix: MediaPipeエラーレスポンスにサイズ制限を追加

### DIFF
--- a/backend/internal/handler/handler_test.go
+++ b/backend/internal/handler/handler_test.go
@@ -401,3 +401,29 @@ func TestAnalyzeVideo_FallbackWhenWorkerUnavailable(t *testing.T) {
 		t.Fatalf("expected 8 phases in fallback, got %d", len(resp.Data.Phases))
 	}
 }
+
+func TestAnalyzeVideo_WorkerReturnsError(t *testing.T) {
+	// MediaPipeワーカーがエラーを返す場合にフォールバックが使われることを確認
+	s := store.New()
+	h := handler.New(s)
+
+	body := `{"videoId":"video-001","userId":"user-001"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/analyses/analyze", bytes.NewBufferString(body))
+	rec := httptest.NewRecorder()
+	h.AnalyzeVideo(rec, req)
+
+	// ワーカーが起動していないためフォールバック
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rec.Code)
+	}
+
+	var resp envelope[model.Analysis]
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	// フォールバック分析が8フェーズすべてのスコアを持つことを確認
+	scores := resp.Data.Scores
+	if scores.Ashibumi == 0 && scores.Dozukuri == 0 && scores.Kai == 0 {
+		t.Fatal("expected non-zero fallback scores")
+	}
+}

--- a/backend/internal/handler/mediapipe.go
+++ b/backend/internal/handler/mediapipe.go
@@ -71,7 +71,10 @@ func (h *Handler) callMediaPipeWorker(ctx context.Context, video model.Video, us
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		respBody, readErr := io.ReadAll(resp.Body)
+		// エラーレスポンスのサイズを1MBに制限し、メモリ枯渇を防止
+		const maxErrorResponseSize = 1 << 20
+		limitedReader := io.LimitReader(resp.Body, maxErrorResponseSize)
+		respBody, readErr := io.ReadAll(limitedReader)
 		if readErr != nil {
 			return model.Analysis{}, fmt.Errorf("MediaPipe worker returned status %d, failed to read body: %w", resp.StatusCode, readErr)
 		}


### PR DESCRIPTION
## Summary
- MediaPipeワーカーのエラーレスポンス読み込みに `io.LimitReader` (1MB) を追加し、メモリ枯渇リスクを解消
- フォールバック分析のテストケースを追加

## Test plan
- [x] `go vet ./...` パス
- [x] `go test -race ./...` パス (既存+新規テスト)
- [x] フロントエンドテスト・lint・typecheck・build 全パス