### PR TITLE
fix: フロント品質改善（エラーUI・APIファサード一元化・テスト安定化・バンドル確認）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,10 +19,13 @@
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.2",
 				"@playwright/test": "^1.61.1",
+				"@testing-library/dom": "^10.4.1",
+				"@testing-library/react": "^16.3.2",
 				"@types/react": "^19.2.17",
 				"@types/react-dom": "^19.0.0",
 				"@vitejs/plugin-react": "^6.0.3",
 				"@vitest/coverage-v8": "^4.1.10",
+				"jsdom": "^27.4.0",
 				"oxlint": "^1.72.0",
 				"typescript": "^6.0.3",
 				"vite": "^8.1.3",
@@ -31,6 +34,70 @@
 			"engines": {
 				"node": ">=22.0.0"
 			}
+		},
+		"node_modules/@acemir/cssom": {
+			"version": "0.9.31",
+			"resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+			"integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+			"integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/css-calc": "^3.0.0",
+				"@csstools/css-color-parser": "^4.0.1",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0",
+				"lru-cache": "^11.2.5"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "6.8.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+			"integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.1.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.2.6"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/code-frame/node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@babel/helper-string-parser": {
 			"version": "7.27.1",
@@ -43,9 +110,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -66,6 +133,16 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/types": {
@@ -161,9 +238,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -181,9 +255,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -201,9 +272,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -221,9 +289,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -267,6 +332,146 @@
 				"node": ">=14.21.3"
 			}
 		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+			"integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+			"integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.1.0",
+				"@csstools/css-calc": "^3.2.1"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+			"integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
 		"node_modules/@emnapi/core": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -299,6 +504,24 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@hookform/resolvers": {
@@ -497,9 +720,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -517,9 +737,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -537,9 +754,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -557,9 +771,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -577,9 +788,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -597,9 +805,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -617,9 +822,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -637,9 +839,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -852,9 +1051,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -872,9 +1068,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -892,9 +1085,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -912,9 +1102,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -932,9 +1119,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -952,9 +1136,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1053,6 +1234,54 @@
 			"integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
 			"license": "MIT"
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"picocolors": "1.1.1",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@testing-library/react": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+			"integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": "^10.0.0",
+				"@types/react": "^18.0.0 || ^19.0.0",
+				"@types/react-dom": "^18.0.0 || ^19.0.0",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1063,6 +1292,13 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
@@ -1348,6 +1584,49 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/aria-query": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
+		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1368,6 +1647,16 @@
 				"@jridgewell/trace-mapping": "^0.3.31",
 				"estree-walker": "^3.0.3",
 				"js-tokens": "^10.0.0"
+			}
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
 			}
 		},
 		"node_modules/chai": {
@@ -1401,6 +1690,36 @@
 			"resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
 			"integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
 			"license": "MIT"
+		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/cssstyle": {
+			"version": "5.3.7",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+			"integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^4.1.1",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+				"css-tree": "^3.1.0",
+				"lru-cache": "^11.2.4"
+			},
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
@@ -1530,11 +1849,70 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/data-urls": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+			"integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^15.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/data-urls/node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/decimal.js-light": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
 			"integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
 			"license": "MIT"
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/detect-libc": {
 			"version": "2.1.2",
@@ -1544,6 +1922,26 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/es-module-lexer": {
@@ -1632,12 +2030,53 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
 		},
 		"node_modules/immer": {
 			"version": "11.1.11",
@@ -1657,6 +2096,13 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -1703,6 +2149,46 @@
 			"integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/jsdom": {
+			"version": "27.4.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+			"integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@acemir/cssom": "^0.9.28",
+				"@asamuzakjp/dom-selector": "^6.7.6",
+				"@exodus/bytes": "^1.6.0",
+				"cssstyle": "^5.3.4",
+				"data-urls": "^6.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"parse5": "^8.0.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.0",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^15.1.0",
+				"ws": "^8.18.3",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/lightningcss": {
 			"version": "1.32.0",
@@ -1965,6 +2451,26 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"lz-string": "bin/bin.js"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2015,6 +2521,20 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.15",
@@ -2093,6 +2613,19 @@
 				"vite-plus": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/pathe": {
@@ -2181,6 +2714,38 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/react": {
@@ -2316,6 +2881,16 @@
 				"redux": "^5.0.0"
 			}
 		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/reselect": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
@@ -2354,6 +2929,19 @@
 				"@rolldown/binding-wasm32-wasi": "1.1.3",
 				"@rolldown/binding-win32-arm64-msvc": "1.1.3",
 				"@rolldown/binding-win32-x64-msvc": "1.1.3"
+			}
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
 			}
 		},
 		"node_modules/scheduler": {
@@ -2406,6 +2994,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tiny-invariant": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -2454,6 +3049,52 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tldts": {
+			"version": "7.4.7",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.7.tgz",
+			"integrity": "sha512-56L0/9HELHSsG1bFCzay8UoLxzRL7kpFf7Wl5q/kSYwiSJGACvro61xnKzPNM+SadxllzdtXsKDSXE7HPeqIAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.4.7"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.4.7",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.7.tgz",
+			"integrity": "sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+			"integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/tslib": {
@@ -2692,6 +3333,53 @@
 				}
 			}
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+			"integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2708,6 +3396,45 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/ws": {
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/zod": {
 			"version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,13 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.2",
 		"@playwright/test": "^1.61.1",
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/react": "^16.3.2",
 		"@types/react": "^19.2.17",
 		"@types/react-dom": "^19.0.0",
 		"@vitejs/plugin-react": "^6.0.3",
 		"@vitest/coverage-v8": "^4.1.10",
+		"jsdom": "^27.4.0",
 		"oxlint": "^1.72.0",
 		"typescript": "^6.0.3",
 		"vite": "^8.1.3",

--- a/src/components/practice/PracticeForm.test.tsx
+++ b/src/components/practice/PracticeForm.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getLocalDateString } from "@/lib/date-utils";
+import { PracticeForm } from "./PracticeForm";
+
+describe("PracticeForm 初期日付（テスト安定化）", () => {
+	afterEach(() => {
+		cleanup();
+		vi.useRealTimers();
+	});
+
+	it("注入した defaultDate を日付入力の初期値に使う", () => {
+		render(<PracticeForm onSubmit={vi.fn()} defaultDate="2026-01-15" />);
+		const input = screen.getByLabelText("日付") as HTMLInputElement;
+		expect(input.value).toBe("2026-01-15");
+	});
+
+	it("defaultDate 未指定時は現在のローカル日付を使う（new Date に依存せず固定可能）", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-05T05:00:00Z"));
+		render(<PracticeForm onSubmit={vi.fn()} />);
+		const input = screen.getByLabelText("日付") as HTMLInputElement;
+		expect(input.value).toBe(getLocalDateString());
+	});
+});

--- a/src/components/practice/PracticeForm.tsx
+++ b/src/components/practice/PracticeForm.tsx
@@ -1,15 +1,16 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Resolver } from "react-hook-form";
 import { useForm } from "react-hook-form";
-import { getLocalDateString } from "@/lib/date-utils";
-import { type PracticeFormValues, practiceFormSchema } from "@/lib/validation";
+import { getPracticeFormDefaults, type PracticeFormValues, practiceFormSchema } from "@/lib/validation";
 
 interface PracticeFormProps {
 	readonly onSubmit: (values: PracticeFormValues) => void;
 	readonly isSubmitting?: boolean;
+	/** 初期日付（YYYY-MM-DD）。テストで時刻を固定するために注入可能。省略時は本日。 */
+	readonly defaultDate?: string;
 }
 
-export function PracticeForm({ onSubmit, isSubmitting = false }: PracticeFormProps) {
+export function PracticeForm({ onSubmit, isSubmitting = false, defaultDate }: PracticeFormProps) {
 	const resolver: Resolver<PracticeFormValues> = zodResolver(practiceFormSchema);
 	const {
 		register,
@@ -17,13 +18,7 @@ export function PracticeForm({ onSubmit, isSubmitting = false }: PracticeFormPro
 		formState: { errors },
 	} = useForm<PracticeFormValues>({
 		resolver,
-		defaultValues: {
-			date: getLocalDateString(),
-			hitRate: 0,
-			arrowCount: 1,
-			notes: "",
-			instructorComment: "",
-		},
+		defaultValues: getPracticeFormDefaults(defaultDate),
 	});
 
 	const fieldStyle = {

--- a/src/components/practice/PracticeList.test.tsx
+++ b/src/components/practice/PracticeList.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { Practice, User } from "@/types/domain";
+import { PracticeList } from "./PracticeList";
+
+const user: User = {
+	id: "user-001",
+	name: "田中太郎",
+	email: "tanaka@example.com",
+	role: "practitioner",
+	dan: "sandan",
+	joinedAt: "2020-04-01",
+	createdAt: "2020-04-01T00:00:00Z",
+	updatedAt: "2020-04-01T00:00:00Z",
+};
+
+const practice: Practice = {
+	id: "practice-001",
+	userId: "user-001",
+	date: "2026-04-01",
+	hitRate: 70,
+	arrowCount: 20,
+	notes: "気づきメモ",
+	instructorComment: "",
+	createdAt: "2026-04-01T00:00:00Z",
+	updatedAt: "2026-04-01T00:00:00Z",
+};
+
+describe("PracticeList（ファサード経由の users プロップで名前解決）", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it("props で渡された users からユーザー名と段位を表示する", () => {
+		render(<PracticeList practices={[practice]} users={[user]} />);
+		// モック直参照ではなく props の users から解決される
+		expect(screen.getByText(/田中太郎 \(三段\)/)).toBeTruthy();
+	});
+
+	it("users に存在しない userId は id をフォールバック表示する", () => {
+		const orphan: Practice = {
+			...practice,
+			id: "practice-002",
+			userId: "unknown-user",
+		};
+		render(<PracticeList practices={[orphan]} users={[user]} />);
+		expect(screen.getByText(/unknown-user/)).toBeTruthy();
+	});
+});

--- a/src/components/practice/PracticeList.tsx
+++ b/src/components/practice/PracticeList.tsx
@@ -1,19 +1,20 @@
-import { MOCK_USERS } from "@/lib/mock-data";
-import type { Practice } from "@/types/domain";
+import type { Practice, User } from "@/types/domain";
 import { DAN_LABELS } from "@/types/domain";
 
 interface PracticeListProps {
 	readonly practices: readonly Practice[];
+	/** ユーザー名解決用のユーザー一覧（api.ts ファサード経由で取得したもの） */
+	readonly users: readonly User[];
 }
 
-function getUserName(userId: string): string {
-	const user = MOCK_USERS.find((u) => u.id === userId);
+function resolveUserName(users: readonly User[], userId: string): string {
+	const user = users.find((u) => u.id === userId);
 	if (!user) return userId;
 	const danLabel = user.dan ? ` (${DAN_LABELS[user.dan]})` : "";
 	return `${user.name}${danLabel}`;
 }
 
-export function PracticeList({ practices }: PracticeListProps) {
+export function PracticeList({ practices, users }: PracticeListProps) {
 	if (practices.length === 0) {
 		return <p>稽古記録がありません</p>;
 	}
@@ -54,7 +55,7 @@ export function PracticeList({ practices }: PracticeListProps) {
 							marginBottom: "0.25rem",
 						}}
 					>
-						{getUserName(practice.userId)} / 矢数: {practice.arrowCount}本
+						{resolveUserName(users, practice.userId)} / 矢数: {practice.arrowCount}本
 					</div>
 					{practice.notes && <p style={{ margin: "0.5rem 0 0", fontSize: "0.9rem" }}>{practice.notes}</p>}
 					{practice.instructorComment && (

--- a/src/components/reservation/ReservationCalendar.tsx
+++ b/src/components/reservation/ReservationCalendar.tsx
@@ -1,6 +1,5 @@
-import { MOCK_USERS } from "@/lib/mock-data";
 import { generateTimeSlots } from "@/lib/reservation-validation";
-import type { Dojo, Reservation } from "@/types/domain";
+import type { Dojo, Reservation, User } from "@/types/domain";
 
 interface ReservationCalendarProps {
 	readonly dojo: Dojo;
@@ -8,10 +7,8 @@ interface ReservationCalendarProps {
 	readonly selectedDate: string;
 	readonly onDateChange: (date: string) => void;
 	readonly onDeleteReservation: (id: string) => void;
-}
-
-function getUserName(userId: string): string {
-	return MOCK_USERS.find((u) => u.id === userId)?.name ?? userId;
+	/** ユーザー名解決用のユーザー一覧（api.ts ファサード経由で取得したもの） */
+	readonly users: readonly User[];
 }
 
 export function ReservationCalendar({
@@ -20,7 +17,10 @@ export function ReservationCalendar({
 	selectedDate,
 	onDateChange,
 	onDeleteReservation,
+	users,
 }: ReservationCalendarProps) {
+	const resolveUserName = (userId: string): string => users.find((u) => u.id === userId)?.name ?? userId;
+
 	const timeSlots = generateTimeSlots(dojo.openTime, dojo.closeTime);
 	const lanes = Array.from({ length: dojo.targetLanes }, (_, i) => i + 1);
 
@@ -114,7 +114,7 @@ export function ReservationCalendar({
 										>
 											{reservation ? (
 												<div>
-													<div>{getUserName(reservation.userId)}</div>
+													<div>{resolveUserName(reservation.userId)}</div>
 													<button
 														type="button"
 														onClick={() => onDeleteReservation(reservation.id)}

--- a/src/components/reservation/ReservationForm.tsx
+++ b/src/components/reservation/ReservationForm.tsx
@@ -1,17 +1,23 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { Resolver } from "react-hook-form";
 import { useForm } from "react-hook-form";
-import { getLocalDateString } from "@/lib/date-utils";
-import { generateTimeSlots, type ReservationFormValues, reservationFormSchema } from "@/lib/reservation-validation";
+import {
+	generateTimeSlots,
+	getReservationFormDefaults,
+	type ReservationFormValues,
+	reservationFormSchema,
+} from "@/lib/reservation-validation";
 import type { Dojo } from "@/types/domain";
 
 interface ReservationFormProps {
 	readonly dojo: Dojo;
 	readonly onSubmit: (values: ReservationFormValues) => void;
 	readonly isSubmitting?: boolean;
+	/** 初期日付（YYYY-MM-DD）。テストで時刻を固定するために注入可能。省略時は本日。 */
+	readonly defaultDate?: string;
 }
 
-export function ReservationForm({ dojo, onSubmit, isSubmitting = false }: ReservationFormProps) {
+export function ReservationForm({ dojo, onSubmit, isSubmitting = false, defaultDate }: ReservationFormProps) {
 	const resolver: Resolver<ReservationFormValues> = zodResolver(reservationFormSchema);
 	const {
 		register,
@@ -19,11 +25,7 @@ export function ReservationForm({ dojo, onSubmit, isSubmitting = false }: Reserv
 		formState: { errors },
 	} = useForm<ReservationFormValues>({
 		resolver,
-		defaultValues: {
-			date: getLocalDateString(),
-			startTime: "",
-			laneNumber: 1,
-		},
+		defaultValues: getReservationFormDefaults(defaultDate),
 	});
 
 	const timeSlots = generateTimeSlots(dojo.openTime, dojo.closeTime);

--- a/src/lib/api-real.ts
+++ b/src/lib/api-real.ts
@@ -1,0 +1,183 @@
+/**
+ * 実 API 実装層
+ *
+ * Go バックエンド (REST API) に HTTP リクエストを送信する。低レベルの
+ * HTTP・エラーハンドリングは api-client.ts に委譲し、mock-api.ts と同じ
+ * インターフェースを提供する。呼び出し側の切り替えは api.ts で一元管理する。
+ */
+import { apiDelete, apiGet, apiPatch, apiPost } from "@/lib/api-client";
+import type { Analysis, ApiResult, Dojo, ExamChecklist, Practice, Reservation, User, Video } from "@/types/domain";
+
+// ---------------------------------------------------------------------------
+// Users API
+// ---------------------------------------------------------------------------
+
+export async function getUsers(): Promise<ApiResult<readonly User[]>> {
+	return apiGet<readonly User[]>("/api/users");
+}
+
+export async function getUser(id: string): Promise<ApiResult<User>> {
+	return apiGet<User>(`/api/users/${encodeURIComponent(id)}`);
+}
+
+export async function getUsersByDojo(dojoId: string): Promise<ApiResult<readonly User[]>> {
+	return apiGet<readonly User[]>(`/api/users?dojoId=${encodeURIComponent(dojoId)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Dojos API
+// ---------------------------------------------------------------------------
+
+export async function getDojos(): Promise<ApiResult<readonly Dojo[]>> {
+	return apiGet<readonly Dojo[]>("/api/dojos");
+}
+
+export async function getDojo(id: string): Promise<ApiResult<Dojo>> {
+	return apiGet<Dojo>(`/api/dojos/${encodeURIComponent(id)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Practices API
+// ---------------------------------------------------------------------------
+
+export async function getPractices(userId?: string): Promise<ApiResult<readonly Practice[]>> {
+	const qs = userId ? `?userId=${encodeURIComponent(userId)}` : "";
+	return apiGet<readonly Practice[]>(`/api/practices${qs}`);
+}
+
+export async function getPractice(id: string): Promise<ApiResult<Practice>> {
+	return apiGet<Practice>(`/api/practices/${encodeURIComponent(id)}`);
+}
+
+export interface CreatePracticeInput {
+	readonly userId: string;
+	readonly dojoId?: string;
+	readonly date: string;
+	readonly hitRate: number;
+	readonly arrowCount: number;
+	readonly notes: string;
+	readonly instructorComment: string;
+}
+
+export async function createPractice(input: CreatePracticeInput): Promise<ApiResult<Practice>> {
+	return apiPost<Practice>("/api/practices", input);
+}
+
+// ---------------------------------------------------------------------------
+// Videos API
+// ---------------------------------------------------------------------------
+
+export async function getVideos(userId?: string): Promise<ApiResult<readonly Video[]>> {
+	const qs = userId ? `?userId=${encodeURIComponent(userId)}` : "";
+	return apiGet<readonly Video[]>(`/api/videos${qs}`);
+}
+
+export async function getVideo(id: string): Promise<ApiResult<Video>> {
+	return apiGet<Video>(`/api/videos/${encodeURIComponent(id)}`);
+}
+
+export interface CreateVideoInput {
+	readonly userId: string;
+	readonly practiceId?: string;
+	readonly fileName: string;
+	readonly fileSize: number;
+	readonly duration: number;
+	readonly mimeType: "video/mp4" | "video/quicktime" | "video/webm";
+	readonly url: string;
+}
+
+export async function createVideo(input: CreateVideoInput): Promise<ApiResult<Video>> {
+	return apiPost<Video>("/api/videos", input);
+}
+
+// ---------------------------------------------------------------------------
+// Analyses API
+// ---------------------------------------------------------------------------
+
+export async function getAnalyses(userId?: string): Promise<ApiResult<readonly Analysis[]>> {
+	const qs = userId ? `?userId=${encodeURIComponent(userId)}` : "";
+	return apiGet<readonly Analysis[]>(`/api/analyses${qs}`);
+}
+
+export async function getAnalysis(id: string): Promise<ApiResult<Analysis>> {
+	return apiGet<Analysis>(`/api/analyses/${encodeURIComponent(id)}`);
+}
+
+export async function getAnalysisByVideo(videoId: string): Promise<ApiResult<Analysis>> {
+	return apiGet<Analysis>(`/api/analyses/video/${encodeURIComponent(videoId)}`);
+}
+
+export interface AnalyzeVideoInput {
+	readonly videoId: string;
+	readonly userId: string;
+}
+
+export async function analyzeVideo(input: AnalyzeVideoInput): Promise<ApiResult<Analysis>> {
+	return apiPost<Analysis>("/api/analyses/analyze", input);
+}
+
+// ---------------------------------------------------------------------------
+// Reservations API
+// ---------------------------------------------------------------------------
+
+export async function getReservations(dojoId?: string, date?: string): Promise<ApiResult<readonly Reservation[]>> {
+	const params = new URLSearchParams();
+	if (dojoId) params.set("dojoId", dojoId);
+	if (date) params.set("date", date);
+	const qs = params.toString() ? `?${params.toString()}` : "";
+	return apiGet<readonly Reservation[]>(`/api/reservations${qs}`);
+}
+
+export async function getReservation(id: string): Promise<ApiResult<Reservation>> {
+	return apiGet<Reservation>(`/api/reservations/${encodeURIComponent(id)}`);
+}
+
+export interface CreateReservationInput {
+	readonly dojoId: string;
+	readonly userId: string;
+	readonly laneNumber: number;
+	readonly date: string;
+	readonly startTime: string;
+	readonly endTime: string;
+}
+
+export async function createReservation(input: CreateReservationInput): Promise<ApiResult<Reservation>> {
+	return apiPost<Reservation>("/api/reservations", input);
+}
+
+export async function deleteReservation(id: string): Promise<ApiResult<{ readonly deleted: true }>> {
+	return apiDelete<{ readonly deleted: true }>(`/api/reservations/${encodeURIComponent(id)}`);
+}
+
+// ---------------------------------------------------------------------------
+// Exam Checklists API
+// ---------------------------------------------------------------------------
+
+export async function getExamChecklists(userId?: string): Promise<ApiResult<readonly ExamChecklist[]>> {
+	const qs = userId ? `?userId=${encodeURIComponent(userId)}` : "";
+	return apiGet<readonly ExamChecklist[]>(`/api/exam-checklists${qs}`);
+}
+
+export async function getExamChecklist(id: string): Promise<ApiResult<ExamChecklist>> {
+	return apiGet<ExamChecklist>(`/api/exam-checklists/${encodeURIComponent(id)}`);
+}
+
+export async function toggleChecklistItem(checklistId: string, itemId: string): Promise<ApiResult<ExamChecklist>> {
+	return apiPatch<ExamChecklist>(
+		`/api/exam-checklists/${encodeURIComponent(checklistId)}/items/${encodeURIComponent(itemId)}/toggle`,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard API
+// ---------------------------------------------------------------------------
+
+export interface DashboardSummary {
+	readonly todayReservationCount: number;
+	readonly totalMemberCount: number;
+	readonly todayReservations: readonly Reservation[];
+}
+
+export async function getDashboardSummary(dojoId: string): Promise<ApiResult<DashboardSummary>> {
+	return apiGet<DashboardSummary>(`/api/dashboard/${encodeURIComponent(dojoId)}`);
+}

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { analyzeVideo, getUsers } from "@/lib/api";
+
+// テスト環境では VITE_API_BASE_URL が未設定のため、ファサードはモック実装に
+// フォールバックする。ここではファサードがモック経由でデータを返すこと
+// （＝ mock/real 切り替えが api.ts に一元化されていること）を検証する。
+describe("api ファサード（モックフォールバック）", () => {
+	it("getUsers がモックのユーザー一覧を返す", async () => {
+		const result = await getUsers();
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.length).toBeGreaterThanOrEqual(10);
+		}
+	});
+
+	it("analyzeVideo が videoId から決定的な分析結果を返す", async () => {
+		const first = await analyzeVideo({
+			videoId: "video-xyz",
+			userId: "user-001",
+		});
+		const second = await analyzeVideo({
+			videoId: "video-xyz",
+			userId: "user-001",
+		});
+		expect(first.success && second.success).toBe(true);
+		if (first.success && second.success) {
+			// スコアは videoId から決定的に生成されるため 2 回の呼び出しで一致する
+			expect(first.data.scores).toEqual(second.data.scores);
+			expect(first.data.overallScore).toBe(second.data.overallScore);
+			expect(first.data.phases.length).toBe(8);
+			expect(first.data.overallScore).toBeGreaterThanOrEqual(0);
+			expect(first.data.overallScore).toBeLessThanOrEqual(100);
+		}
+	});
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,267 +1,61 @@
 /**
- * API クライアント層
+ * API ファサード層
  *
- * Go バックエンド (REST API) に HTTP リクエストを送信する。
- * mock-api.ts と同じインターフェースを維持し、差し替え可能にする。
+ * アプリの全コンポーネントはこのモジュール経由で API を呼び出す。
+ * VITE_API_BASE_URL が設定されていれば実 Go バックエンド (api-real)、
+ * 未設定ならインメモリのモック (mock-api) を使う。モック↔実 API の
+ * 切り替えはここで一元管理し、呼び出し側は切り替えを意識しない。
  */
-import type { Analysis, ApiResult, Dojo, ExamChecklist, Practice, Reservation, User, Video } from "@/types/domain";
+import { isRealApiEnabled } from "@/lib/api-client";
+import * as realApi from "@/lib/api-real";
+import * as mockApi from "@/lib/mock-api";
 
-// ---------------------------------------------------------------------------
-// Configuration
-// ---------------------------------------------------------------------------
+const impl = isRealApiEnabled() ? realApi : mockApi;
 
-const API_BASE_URL = (import.meta.env["VITE_API_BASE_URL"] as string | undefined) ?? "";
+// Users
+export const getUsers = impl.getUsers;
+export const getUser = impl.getUser;
+export const getUsersByDojo = impl.getUsersByDojo;
 
-// ---------------------------------------------------------------------------
-// Type guards
-// ---------------------------------------------------------------------------
+// Dojos
+export const getDojos = impl.getDojos;
+export const getDojo = impl.getDojo;
 
-/** Go APIの成功レスポンス構造を検証する型ガード */
-function isApiSuccess<T>(value: unknown): value is { success: true; data: T } {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		"success" in value &&
-		(value as Record<string, unknown>)["success"] === true &&
-		"data" in value
-	);
-}
+// Practices
+export const getPractices = impl.getPractices;
+export const getPractice = impl.getPractice;
+export const createPractice = impl.createPractice;
 
-/** Go APIのエラーレスポンス構造を検証する型ガード */
-function isApiError(value: unknown): value is {
-	success: false;
-	error: { code: string; message: string };
-} {
-	if (typeof value !== "object" || value === null || !("success" in value)) {
-		return false;
-	}
-	const obj = value as Record<string, unknown>;
-	if (obj["success"] !== false || typeof obj["error"] !== "object" || obj["error"] === null) {
-		return false;
-	}
-	const err = obj["error"] as Record<string, unknown>;
-	return typeof err["code"] === "string" && typeof err["message"] === "string";
-}
+// Videos
+export const getVideos = impl.getVideos;
+export const getVideo = impl.getVideo;
+export const createVideo = impl.createVideo;
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
+// Analyses
+export const getAnalyses = impl.getAnalyses;
+export const getAnalysis = impl.getAnalysis;
+export const getAnalysisByVideo = impl.getAnalysisByVideo;
+export const analyzeVideo = impl.analyzeVideo;
 
-async function apiFetch<T>(path: string, init?: RequestInit): Promise<ApiResult<T>> {
-	try {
-		const response = await fetch(`${API_BASE_URL}${path}`, {
-			headers: { "Content-Type": "application/json" },
-			...init,
-		});
+// Reservations
+export const getReservations = impl.getReservations;
+export const getReservation = impl.getReservation;
+export const createReservation = impl.createReservation;
+export const deleteReservation = impl.deleteReservation;
 
-		const json: unknown = await response.json();
+// Exam Checklists
+export const getExamChecklists = impl.getExamChecklists;
+export const getExamChecklist = impl.getExamChecklist;
+export const toggleChecklistItem = impl.toggleChecklistItem;
 
-		// The Go API returns { success: true/false, data/error }
-		if (isApiSuccess<T>(json)) {
-			return json;
-		}
-		if (isApiError(json)) {
-			return json;
-		}
+// Dashboard
+export const getDashboardSummary = impl.getDashboardSummary;
 
-		return {
-			success: false,
-			error: { code: "UNKNOWN", message: "予期しないレスポンス形式です" },
-		};
-	} catch (err: unknown) {
-		const message = err instanceof Error ? err.message : "通信エラーが発生しました";
-		return {
-			success: false,
-			error: { code: "NETWORK_ERROR", message },
-		};
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Users API
-// ---------------------------------------------------------------------------
-
-export async function getUsers(): Promise<ApiResult<readonly User[]>> {
-	return apiFetch<readonly User[]>("/api/users");
-}
-
-export async function getUser(id: string): Promise<ApiResult<User>> {
-	return apiFetch<User>(`/api/users/${encodeURIComponent(id)}`);
-}
-
-export async function getUsersByDojo(dojoId: string): Promise<ApiResult<readonly User[]>> {
-	return apiFetch<readonly User[]>(`/api/users?dojoId=${encodeURIComponent(dojoId)}`);
-}
-
-// ---------------------------------------------------------------------------
-// Dojos API
-// ---------------------------------------------------------------------------
-
-export async function getDojos(): Promise<ApiResult<readonly Dojo[]>> {
-	return apiFetch<readonly Dojo[]>("/api/dojos");
-}
-
-export async function getDojo(id: string): Promise<ApiResult<Dojo>> {
-	return apiFetch<Dojo>(`/api/dojos/${encodeURIComponent(id)}`);
-}
-
-// ---------------------------------------------------------------------------
-// Practices API
-// ---------------------------------------------------------------------------
-
-export async function getPractices(userId?: string): Promise<ApiResult<readonly Practice[]>> {
-	const qs = userId ? `?userId=${encodeURIComponent(userId)}` : "";
-	return apiFetch<readonly Practice[]>(`/api/practices${qs}`);
-}
-
-export async function getPractice(id: string): Promise<ApiResult<Practice>> {
-	return apiFetch<Practice>(`/api/practices/${encodeURIComponent(id)}`);
-}
-
-export interface CreatePracticeInput {
-	readonly userId: string;
-	readonly dojoId?: string;
-	readonly date: string;
-	readonly hitRate: number;
-	readonly arrowCount: number;
-	readonly notes: string;
-	readonly instructorComment: string;
-}
-
-export async function createPractice(input: CreatePracticeInput): Promise<ApiResult<Practice>> {
-	return apiFetch<Practice>("/api/practices", {
-		method: "POST",
-		body: JSON.stringify(input),
-	});
-}
-
-// ---------------------------------------------------------------------------
-// Videos API
-// ---------------------------------------------------------------------------
-
-export async function getVideos(userId?: string): Promise<ApiResult<readonly Video[]>> {
-	const qs = userId ? `?userId=${encodeURIComponent(userId)}` : "";
-	return apiFetch<readonly Video[]>(`/api/videos${qs}`);
-}
-
-export async function getVideo(id: string): Promise<ApiResult<Video>> {
-	return apiFetch<Video>(`/api/videos/${encodeURIComponent(id)}`);
-}
-
-export interface CreateVideoInput {
-	readonly userId: string;
-	readonly practiceId?: string;
-	readonly fileName: string;
-	readonly fileSize: number;
-	readonly duration: number;
-	readonly mimeType: "video/mp4" | "video/quicktime" | "video/webm";
-	readonly url: string;
-}
-
-export async function createVideo(input: CreateVideoInput): Promise<ApiResult<Video>> {
-	return apiFetch<Video>("/api/videos", {
-		method: "POST",
-		body: JSON.stringify(input),
-	});
-}
-
-// ---------------------------------------------------------------------------
-// Analyses API
-// ---------------------------------------------------------------------------
-
-export async function getAnalyses(userId?: string): Promise<ApiResult<readonly Analysis[]>> {
-	const qs = userId ? `?userId=${encodeURIComponent(userId)}` : "";
-	return apiFetch<readonly Analysis[]>(`/api/analyses${qs}`);
-}
-
-export async function getAnalysis(id: string): Promise<ApiResult<Analysis>> {
-	return apiFetch<Analysis>(`/api/analyses/${encodeURIComponent(id)}`);
-}
-
-export async function getAnalysisByVideo(videoId: string): Promise<ApiResult<Analysis>> {
-	return apiFetch<Analysis>(`/api/analyses/video/${encodeURIComponent(videoId)}`);
-}
-
-export interface AnalyzeVideoInput {
-	readonly videoId: string;
-	readonly userId: string;
-}
-
-export async function analyzeVideo(input: AnalyzeVideoInput): Promise<ApiResult<Analysis>> {
-	return apiFetch<Analysis>("/api/analyses/analyze", {
-		method: "POST",
-		body: JSON.stringify(input),
-	});
-}
-
-// ---------------------------------------------------------------------------
-// Reservations API
-// ---------------------------------------------------------------------------
-
-export async function getReservations(dojoId?: string, date?: string): Promise<ApiResult<readonly Reservation[]>> {
-	const params = new URLSearchParams();
-	if (dojoId) params.set("dojoId", dojoId);
-	if (date) params.set("date", date);
-	const qs = params.toString() ? `?${params.toString()}` : "";
-	return apiFetch<readonly Reservation[]>(`/api/reservations${qs}`);
-}
-
-export async function getReservation(id: string): Promise<ApiResult<Reservation>> {
-	return apiFetch<Reservation>(`/api/reservations/${encodeURIComponent(id)}`);
-}
-
-export interface CreateReservationInput {
-	readonly dojoId: string;
-	readonly userId: string;
-	readonly laneNumber: number;
-	readonly date: string;
-	readonly startTime: string;
-	readonly endTime: string;
-}
-
-export async function createReservation(input: CreateReservationInput): Promise<ApiResult<Reservation>> {
-	return apiFetch<Reservation>("/api/reservations", {
-		method: "POST",
-		body: JSON.stringify(input),
-	});
-}
-
-export async function deleteReservation(id: string): Promise<ApiResult<{ readonly deleted: true }>> {
-	return apiFetch<{ readonly deleted: true }>(`/api/reservations/${encodeURIComponent(id)}`, {
-		method: "DELETE",
-	});
-}
-
-// ---------------------------------------------------------------------------
-// Exam Checklists API
-// ---------------------------------------------------------------------------
-
-export async function getExamChecklists(userId?: string): Promise<ApiResult<readonly ExamChecklist[]>> {
-	const qs = userId ? `?userId=${encodeURIComponent(userId)}` : "";
-	return apiFetch<readonly ExamChecklist[]>(`/api/exam-checklists${qs}`);
-}
-
-export async function getExamChecklist(id: string): Promise<ApiResult<ExamChecklist>> {
-	return apiFetch<ExamChecklist>(`/api/exam-checklists/${encodeURIComponent(id)}`);
-}
-
-export async function toggleChecklistItem(checklistId: string, itemId: string): Promise<ApiResult<ExamChecklist>> {
-	return apiFetch<ExamChecklist>(
-		`/api/exam-checklists/${encodeURIComponent(checklistId)}/items/${encodeURIComponent(itemId)}/toggle`,
-		{ method: "PATCH" },
-	);
-}
-
-// ---------------------------------------------------------------------------
-// Dashboard API
-// ---------------------------------------------------------------------------
-
-export interface DashboardSummary {
-	readonly todayReservationCount: number;
-	readonly totalMemberCount: number;
-	readonly todayReservations: readonly Reservation[];
-}
-
-export async function getDashboardSummary(dojoId: string): Promise<ApiResult<DashboardSummary>> {
-	return apiFetch<DashboardSummary>(`/api/dashboard/${encodeURIComponent(dojoId)}`);
-}
+// 入力・出力の型定義は実 API 実装と共有する
+export type {
+	AnalyzeVideoInput,
+	CreatePracticeInput,
+	CreateReservationInput,
+	CreateVideoInput,
+	DashboardSummary,
+} from "@/lib/api-real";

--- a/src/lib/mock-api.ts
+++ b/src/lib/mock-api.ts
@@ -6,7 +6,19 @@
  * 意図的な遅延（50-200ms）を追加し、非同期UIの動作確認を可能にする。
  */
 import { getLocalDateString } from "@/lib/date-utils";
-import type { Analysis, ApiResult, Dojo, ExamChecklist, Practice, Reservation, User, Video } from "@/types/domain";
+import type {
+	Analysis,
+	ApiResult,
+	Dojo,
+	ExamChecklist,
+	HassetsuPhase,
+	HassetsuScores,
+	Practice,
+	Reservation,
+	User,
+	Video,
+} from "@/types/domain";
+import { HASSETSU_PHASES } from "@/types/domain";
 import {
 	MOCK_ANALYSES,
 	MOCK_DOJOS,
@@ -228,6 +240,74 @@ export async function getAnalysisByVideo(videoId: string): Promise<ApiResult<Ana
 	await simulateLatency();
 	const analysis = analyses.find((a) => a.videoId === videoId);
 	return analysis ? success(analysis) : notFound("分析結果");
+}
+
+export interface AnalyzeVideoInput {
+	readonly videoId: string;
+	readonly userId: string;
+}
+
+/** シード文字列から決定的に 60〜90 のスコアを生成する（乱数不使用でテスト安定） */
+function seededScore(seed: string, salt: number): number {
+	let h = salt >>> 0;
+	for (let i = 0; i < seed.length; i++) {
+		h = (Math.imul(h, 31) + seed.charCodeAt(i)) >>> 0;
+	}
+	return 60 + (h % 31);
+}
+
+/** videoId から決定的に八節スコアを生成する */
+function generateScores(videoId: string): HassetsuScores {
+	const scores = {} as Record<HassetsuPhase, number>;
+	HASSETSU_PHASES.forEach((phase, idx) => {
+		scores[phase] = seededScore(videoId, idx + 1);
+	});
+	return scores;
+}
+
+/** 八節フェーズの標準的なタイムライン（秒） */
+const PHASE_TIMELINE: ReadonlyArray<{
+	readonly phase: HassetsuPhase;
+	readonly startTime: number;
+	readonly endTime: number;
+}> = [
+	{ phase: "ashibumi", startTime: 0, endTime: 3.5 },
+	{ phase: "dozukuri", startTime: 3.5, endTime: 7.0 },
+	{ phase: "yugamae", startTime: 7.0, endTime: 12.0 },
+	{ phase: "uchiokoshi", startTime: 12.0, endTime: 16.0 },
+	{ phase: "hikiwake", startTime: 16.0, endTime: 24.0 },
+	{ phase: "kai", startTime: 24.0, endTime: 30.0 },
+	{ phase: "hanare", startTime: 30.0, endTime: 31.0 },
+	{ phase: "zanshin", startTime: 31.0, endTime: 35.0 },
+];
+
+/**
+ * 動画の射形分析を実行する（モック）。
+ * 本番 API の POST /api/analyses/analyze に対応する。videoId から決定的に
+ * スコア・総合点を生成し、生成した分析結果をメモリ上のストアに追加する。
+ */
+export async function analyzeVideo(input: AnalyzeVideoInput): Promise<ApiResult<Analysis>> {
+	await simulateLatency();
+
+	const scores = generateScores(input.videoId);
+	const values = HASSETSU_PHASES.map((p) => scores[p]);
+	const overallScore = Math.round(values.reduce((sum, v) => sum + v, 0) / values.length);
+
+	const analysis: Analysis = {
+		id: `analysis-${generateId()}`,
+		videoId: input.videoId,
+		userId: input.userId,
+		scores,
+		phases: PHASE_TIMELINE.map((seg) => ({ ...seg })),
+		overallScore,
+		feedback:
+			overallScore >= 80
+				? "全体的に安定した射。会の伸びが良好。残心の意識をさらに高めるとより良くなる。"
+				: "会での安定感は良好。離れの瞬間の右肩の上がりに注意し、引分けでの左右均等な力配分を意識すること。",
+		createdAt: new Date().toISOString(),
+	};
+	analyses.push(analysis);
+	return success(analysis);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/reservation-validation.test.ts
+++ b/src/lib/reservation-validation.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { generateTimeSlots, getEndTime, reservationFormSchema } from "./reservation-validation";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getLocalDateString } from "./date-utils";
+import {
+	generateTimeSlots,
+	getEndTime,
+	getReservationFormDefaults,
+	reservationFormSchema,
+} from "./reservation-validation";
 
 describe("reservation-validation", () => {
 	describe("reservationFormSchema", () => {
@@ -50,6 +56,27 @@ describe("reservation-validation", () => {
 			expect(getEndTime("09:00")).toBe("10:00");
 			expect(getEndTime("14:00")).toBe("15:00");
 			expect(getEndTime("20:00")).toBe("21:00");
+		});
+	});
+
+	describe("getReservationFormDefaults", () => {
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it("注入した日付を初期値に使う（テスト安定化）", () => {
+			const defaults = getReservationFormDefaults("2026-04-01");
+			expect(defaults).toEqual({
+				date: "2026-04-01",
+				startTime: "",
+				laneNumber: 1,
+			});
+		});
+
+		it("未指定時は現在のローカル日付を使う", () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-04-05T05:00:00Z"));
+			expect(getReservationFormDefaults().date).toBe(getLocalDateString());
 		});
 	});
 });

--- a/src/lib/reservation-validation.ts
+++ b/src/lib/reservation-validation.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { getLocalDateString } from "@/lib/date-utils";
 
 /** 予約フォームのバリデーションスキーマ */
 export const reservationFormSchema = z.object({
@@ -8,6 +9,14 @@ export const reservationFormSchema = z.object({
 });
 
 export type ReservationFormValues = z.infer<typeof reservationFormSchema>;
+
+/**
+ * 予約フォームの初期値を返す。日付はテストで安定させられるよう注入可能。
+ * 未指定時のみ現在日付（ローカル）を用いる。
+ */
+export function getReservationFormDefaults(today: string = getLocalDateString()): ReservationFormValues {
+	return { date: today, startTime: "", laneNumber: 1 };
+}
 
 /** 営業時間内の1時間単位の時間帯を生成 */
 export function generateTimeSlots(openTime: string, closeTime: string): readonly string[] {

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getLocalDateString, getOneYearAgoDateString } from "./date-utils";
-import { practiceFormSchema } from "./validation";
+import { getPracticeFormDefaults, practiceFormSchema } from "./validation";
 
 describe("practiceFormSchema", () => {
 	it("有効な入力を受け付ける", () => {
@@ -140,5 +140,28 @@ describe("practiceFormSchema 日付バリデーション（タイムゾーン非
 		const twoYearsAgo = getLocalDateString(new Date("2024-04-05T05:00:00Z"));
 		const result = practiceFormSchema.safeParse({ ...base, date: twoYearsAgo });
 		expect(result.success).toBe(false);
+	});
+});
+
+describe("getPracticeFormDefaults", () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("注入した日付を初期値に使う（テスト安定化）", () => {
+		const defaults = getPracticeFormDefaults("2026-04-01");
+		expect(defaults).toEqual({
+			date: "2026-04-01",
+			hitRate: 0,
+			arrowCount: 1,
+			notes: "",
+			instructorComment: "",
+		});
+	});
+
+	it("未指定時は現在のローカル日付を使う", () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-04-05T05:00:00Z"));
+		expect(getPracticeFormDefaults().date).toBe(getLocalDateString());
 	});
 });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -25,3 +25,17 @@ export const practiceFormSchema = z.object({
 });
 
 export type PracticeFormValues = z.infer<typeof practiceFormSchema>;
+
+/**
+ * 稽古フォームの初期値を返す。日付はテストで安定させられるよう注入可能。
+ * 未指定時のみ現在日付（ローカル）を用いる。
+ */
+export function getPracticeFormDefaults(today: string = getLocalDateString()): PracticeFormValues {
+	return {
+		date: today,
+		hitRate: 0,
+		arrowCount: 1,
+		notes: "",
+		instructorComment: "",
+	};
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -162,6 +162,7 @@ export function DashboardPage() {
 								selectedDate={selectedDate}
 								onDateChange={setSelectedDate}
 								onDeleteReservation={handleDeleteReservation}
+								users={members}
 							/>
 						</section>
 					</>

--- a/src/pages/ExamChecklistPage.test.tsx
+++ b/src/pages/ExamChecklistPage.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getExamChecklists } from "@/lib/api";
+import { ExamChecklistPage } from "./ExamChecklistPage";
+
+vi.mock("@/lib/api", () => ({
+	getExamChecklists: vi.fn(),
+	toggleChecklistItem: vi.fn(),
+}));
+
+describe("ExamChecklistPage エラーUI", () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("チェックリストの読み込み失敗時に role=alert を表示する", async () => {
+		vi.mocked(getExamChecklists).mockResolvedValue({
+			success: false,
+			error: { code: "HTTP_ERROR", message: "サーバーエラーが発生しました" },
+		});
+
+		render(<ExamChecklistPage />);
+
+		const alert = await screen.findByRole("alert");
+		expect(alert.textContent).toContain("サーバーエラーが発生しました");
+	});
+
+	it("空データ（成功）時はエラーではなく空メッセージを表示する", async () => {
+		vi.mocked(getExamChecklists).mockResolvedValue({ success: true, data: [] });
+
+		render(<ExamChecklistPage />);
+
+		await waitFor(() => {
+			expect(screen.getByText("チェックリストがありません")).toBeTruthy();
+		});
+		expect(screen.queryByRole("alert")).toBeNull();
+	});
+});

--- a/src/pages/ExamChecklistPage.tsx
+++ b/src/pages/ExamChecklistPage.tsx
@@ -6,14 +6,27 @@ import type { ExamChecklist } from "@/types/domain";
 /** 現在のモックユーザーID */
 const CURRENT_USER_ID = "user-001";
 
+const alertStyle = {
+	padding: "1rem",
+	marginBottom: "1.5rem",
+	backgroundColor: "#fef2f2",
+	border: "1px solid #fca5a5",
+	borderRadius: "8px",
+	color: "#991b1b",
+} as const;
+
 export function ExamChecklistPage() {
 	const [checklists, setChecklists] = useState<readonly ExamChecklist[]>([]);
+	const [error, setError] = useState<string | null>(null);
 
 	const loadChecklists = useCallback(async () => {
+		setError(null);
 		const result = await getExamChecklists(CURRENT_USER_ID);
 		if (result.success) {
 			setChecklists(result.data);
+			return;
 		}
+		setError(result.error.message);
 	}, []);
 
 	useEffect(() => {
@@ -24,13 +37,20 @@ export function ExamChecklistPage() {
 		const result = await toggleChecklistItem(checklistId, itemId);
 		if (result.success) {
 			setChecklists((prev) => prev.map((c) => (c.id === result.data.id ? result.data : c)));
+			return;
 		}
+		setError(result.error.message);
 	};
 
 	return (
 		<div>
 			<h1>段位審査チェックリスト</h1>
-			{checklists.length === 0 ? (
+			{error && (
+				<div role="alert" style={alertStyle}>
+					チェックリストの読み込みに失敗しました: {error}
+				</div>
+			)}
+			{!error && checklists.length === 0 ? (
 				<p>チェックリストがありません</p>
 			) : (
 				<div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>

--- a/src/pages/PracticesPage.test.tsx
+++ b/src/pages/PracticesPage.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getPractices, getUsers } from "@/lib/api";
+import { PracticesPage } from "./PracticesPage";
+
+vi.mock("@/lib/api", () => ({
+	getPractices: vi.fn(),
+	getUsers: vi.fn(),
+	createPractice: vi.fn(),
+}));
+// recharts はテスト環境で描画寸法を持たないためスタブ化する
+vi.mock("@/components/practice/HitRateChart", () => ({
+	HitRateChart: () => null,
+}));
+
+describe("PracticesPage エラーUI", () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it("稽古記録の読み込み失敗時に role=alert を表示する", async () => {
+		vi.mocked(getPractices).mockResolvedValue({
+			success: false,
+			error: { code: "NETWORK_ERROR", message: "通信エラーが発生しました" },
+		});
+		vi.mocked(getUsers).mockResolvedValue({ success: true, data: [] });
+
+		render(<PracticesPage />);
+
+		const alert = await screen.findByRole("alert");
+		expect(alert.textContent).toContain("通信エラーが発生しました");
+	});
+
+	it("読み込み成功時はエラーを表示しない", async () => {
+		vi.mocked(getPractices).mockResolvedValue({ success: true, data: [] });
+		vi.mocked(getUsers).mockResolvedValue({ success: true, data: [] });
+
+		render(<PracticesPage />);
+
+		await waitFor(() => {
+			expect(screen.getByText("稽古履歴")).toBeTruthy();
+		});
+		expect(screen.queryByRole("alert")).toBeNull();
+	});
+});

--- a/src/pages/PracticesPage.tsx
+++ b/src/pages/PracticesPage.tsx
@@ -2,31 +2,50 @@ import { useCallback, useEffect, useState } from "react";
 import { HitRateChart } from "@/components/practice/HitRateChart";
 import { PracticeForm } from "@/components/practice/PracticeForm";
 import { PracticeList } from "@/components/practice/PracticeList";
-import { createPractice, getPractices } from "@/lib/api";
+import { createPractice, getPractices, getUsers } from "@/lib/api";
 import type { PracticeFormValues } from "@/lib/validation";
-import type { Practice } from "@/types/domain";
+import type { Practice, User } from "@/types/domain";
 
 /** 現在のモックユーザーID */
 const CURRENT_USER_ID = "user-001";
 
+const alertStyle = {
+	padding: "1rem",
+	marginBottom: "1.5rem",
+	backgroundColor: "#fef2f2",
+	border: "1px solid #fca5a5",
+	borderRadius: "8px",
+	color: "#991b1b",
+} as const;
+
 export function PracticesPage() {
 	const [practices, setPractices] = useState<readonly Practice[]>([]);
+	const [users, setUsers] = useState<readonly User[]>([]);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [showForm, setShowForm] = useState(false);
+	const [loadError, setLoadError] = useState<string | null>(null);
+	const [submitError, setSubmitError] = useState<string | null>(null);
 
-	const loadPractices = useCallback(async () => {
-		const result = await getPractices(CURRENT_USER_ID);
-		if (result.success) {
-			setPractices(result.data);
+	const loadData = useCallback(async () => {
+		setLoadError(null);
+		const [practicesResult, usersResult] = await Promise.all([getPractices(CURRENT_USER_ID), getUsers()]);
+		if (!practicesResult.success) {
+			setLoadError(practicesResult.error.message);
+			return;
+		}
+		setPractices(practicesResult.data);
+		if (usersResult.success) {
+			setUsers(usersResult.data);
 		}
 	}, []);
 
 	useEffect(() => {
-		void loadPractices();
-	}, [loadPractices]);
+		void loadData();
+	}, [loadData]);
 
 	const handleSubmit = async (values: PracticeFormValues) => {
 		setIsSubmitting(true);
+		setSubmitError(null);
 		const result = await createPractice({
 			userId: CURRENT_USER_ID,
 			dojoId: "dojo-001",
@@ -36,8 +55,10 @@ export function PracticesPage() {
 
 		if (result.success) {
 			setShowForm(false);
-			await loadPractices();
+			await loadData();
+			return;
 		}
+		setSubmitError(result.error.message);
 	};
 
 	return (
@@ -67,9 +88,20 @@ export function PracticesPage() {
 				</button>
 			</div>
 
+			{loadError && (
+				<div role="alert" style={alertStyle}>
+					稽古記録の読み込みに失敗しました: {loadError}
+				</div>
+			)}
+
 			{showForm && (
 				<div style={{ marginBottom: "2rem" }}>
 					<h2>稽古を記録</h2>
+					{submitError && (
+						<div role="alert" style={alertStyle}>
+							{submitError}
+						</div>
+					)}
 					<PracticeForm onSubmit={handleSubmit} isSubmitting={isSubmitting} />
 				</div>
 			)}
@@ -81,7 +113,7 @@ export function PracticesPage() {
 
 			<section>
 				<h2>稽古履歴</h2>
-				<PracticeList practices={practices} />
+				<PracticeList practices={practices} users={users} />
 			</section>
 		</div>
 	);


### PR DESCRIPTION
## 概要
フロントエンド品質系 4 件をまとめて対応。

### #23 PracticesPage/ExamChecklistPage のエラーUI欠落
- 読み込み失敗・送信失敗時に `role="alert"` のアクセシブルなエラー表示を追加（DashboardPage と同じ赤系ボックス）。
- jsdom + Testing Library でエラー表示のレンダリングテストを追加。

### #21 モック直参照で api.ts ファサード未経由
- `api.ts` を **mock / 実API 切り替えの単一ファサード**に再構成し、切り替えを一元化。実装は `api-real.ts`（`api-client.ts` 経由の実HTTP）へ分離。`VITE_API_BASE_URL` 未設定時はモックへフォールバック（これまで実装が未完で常に fetch していた挙動を修正）。
- `PracticeList` / `ReservationCalendar` の `MOCK_USERS` 直参照を撤廃し、ユーザー一覧を **props 経由**（親がファサードで取得）に変更。
- `mock-api` に不足していた `analyzeVideo`（決定的生成）を追加し、モック面を実APIと一致させた。

### #30 useForm defaultValues の new Date() 不安定テストリスク
- フォーム初期値を注入可能な純粋関数 `getPracticeFormDefaults` / `getReservationFormDefaults` に抽出。フォームに `defaultDate` prop を追加し、テストで日付を固定可能に。
- 純粋関数テスト（node）＋ フォームレンダリングテスト（jsdom、固定/注入日付）を追加。

### #33 フロントエンドバンドルサイズ確認
- `knip` で未使用 dependencies **0 件**、three.js / @react-three 系は **存在せず**を確認。
- ビルド後チャンク構成を計測（最大は使用中の recharts）。詳細は issue #33 にコメント記録。

## テスト基盤
- `jsdom` + `@testing-library/react` + `@testing-library/dom` を devDependency 追加。コンポーネントテストは per-file `// @vitest-environment jsdom` で実行（既存の node テストは環境そのまま）。

## 検証
- `vitest run` 91 件パス（+8 件: ファサード/フォーム/エラーUI/名前解決）
- `tsc --noEmit` / `oxlint` / `biome check` クリーン、`vite build` 成功

Fixes #23
Fixes #21
Fixes #30
Fixes #33